### PR TITLE
change inject to angular.mock.inject

### DIFF
--- a/app/test/lib/turnerjs-driver.ts
+++ b/app/test/lib/turnerjs-driver.ts
@@ -77,7 +77,7 @@ class TurnerComponentDriver {
   }
 
   protected renderFromTemplate(template: string, args: Object = {}, selector?) {
-    inject(($rootScope: ng.IRootScopeService, $compile: ng.ICompileService) => {
+    angular.mock.inject(($rootScope: ng.IRootScopeService, $compile: ng.ICompileService) => {
       this.$rootScope = $rootScope;
       this.$compile = $compile;
     });


### PR DESCRIPTION
Hey guys,

please consider this really minor change, it makes it more friendly when testing with jsdom - it's one less thing you need to put on the global object.