### PR TITLE
fix types on typescript > 2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "main": "module/generated/turnerjs-driver.js",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
typescript 2.9 change behavior when resolving types of libraries. 
If you try to use `turnerjs` currently on typescript about 2.9 you get this:
`error TS2306: ..../node_modules/turnerjs/module/generated/turnerjs-driver.d.ts' is not a module.`

see here: https://github.com/Microsoft/TypeScript/pull/24112